### PR TITLE
Fix minor typos and 0 codes

### DIFF
--- a/pal_interaction_msgs/msg/ASRActivation.msg
+++ b/pal_interaction_msgs/msg/ASRActivation.msg
@@ -1,10 +1,10 @@
 # Message that can be used to send activation commands to the speech recognizer.
 # It is possible to activate/deactivate or pause/resume the recognizer with these commands.
 # action list
-int8 ACTIVATE = 0
-int8 DEACTIVATE = 1
-int8 PAUSE = 2
-int8 RESUME = 3
+int8 ACTIVATE = 1
+int8 DEACTIVATE = 2
+int8 PAUSE = 3
+int8 RESUME = 4
 # Message variables
 int8 action
 

--- a/pal_interaction_msgs/msg/ASREvent.msg
+++ b/pal_interaction_msgs/msg/ASREvent.msg
@@ -2,10 +2,10 @@
 # This message are published in the ASR event topic.
 # The kind of events that are published are the following ones:
 ## Event types to be published.
-uint8 EVENT_UNDEFINED          = -1
-uint8 EVENT_LISTEN_STATE       = 1
-uint8 EVENT_RECOGNIZED_UTT      = 2
-uint8 EVENT_ASR_ACTIVATION     = 3
+int8 EVENT_UNDEFINED          = -1
+int8 EVENT_LISTEN_STATE       = 1
+int8 EVENT_RECOGNIZED_UTT      = 2
+int8 EVENT_ASR_ACTIVATION     = 3
 
 # 1-> The ASR changed its listening state.
 # 2-> The ASR recognized a full uterance and published the result
@@ -14,10 +14,10 @@ uint8 EVENT_ASR_ACTIVATION     = 3
 # These are the possible listening states published when event_id = LISTENING_STATE
 
 ## Listen states
-uint8 LISTEN_UNDEFINED = 20
-uint8 LISTEN_SPEECH_DETECTED = 21
-uint8 LISTEN_WAITING_FOR_SPEECH = 22
-uint8 LISTEN_END_OF_SPEECH = 23
+int8 LISTEN_UNDEFINED = 20
+int8 LISTEN_SPEECH_DETECTED = 21
+int8 LISTEN_WAITING_FOR_SPEECH = 22
+int8 LISTEN_END_OF_SPEECH = 23
 
 # 21-> Some speech has been detected.
 # 22-> The ASR is waiting for someone to start speaking.
@@ -26,10 +26,10 @@ uint8 LISTEN_END_OF_SPEECH = 23
 ##  Message variables
 
 # The event type published.
-uint8 event_id
+int8 event_id
 
 # The listening state of the ASR
-uint8 listent_state
+int8 listent_state
 
 # The recognized result in case of event_id = RECOGNIZED_UTT
 asrresult recognized_utterance

--- a/pal_interaction_msgs/msg/ASREvent.msg
+++ b/pal_interaction_msgs/msg/ASREvent.msg
@@ -2,16 +2,16 @@
 # This message are published in the ASR event topic.
 # The kind of events that are published are the following ones:
 ## Event types to be published.
-uint8 EVENT_UNDEFINED          = 0
+uint8 EVENT_UNDEFINED          = -1
 uint8 EVENT_LISTEN_STATE       = 1
-uint8 EVENT_RECONISED_UTT      = 2
+uint8 EVENT_RECOGNIZED_UTT      = 2
 uint8 EVENT_ASR_ACTIVATION     = 3
 
 # 1-> The ASR changed its listening state.
-# 2-> The ASR recognised a full uterance and published the result
-# 3-> THe ASR has been activated/deactivated
+# 2-> The ASR recognized a full uterance and published the result
+# 3-> The ASR has been activated/deactivated
 
-# THese are the possible listening states published when event_id = LISTENING_STATE
+# These are the possible listening states published when event_id = LISTENING_STATE
 
 ## Listen states
 uint8 LISTEN_UNDEFINED = 20
@@ -19,19 +19,19 @@ uint8 LISTEN_SPEECH_DETECTED = 21
 uint8 LISTEN_WAITING_FOR_SPEECH = 22
 uint8 LISTEN_END_OF_SPEECH = 23
 
-# 21-> Some speech have been detected
+# 21-> Some speech has been detected.
 # 22-> The ASR is waiting for someone to start speaking.
-# 23-> The end of an utterance have been found, and will start decoding it.
+# 23-> The end of an utterance has been found, and will start decoding it.
 
 ##  Message variables
 
 # The event type published.
 uint8 event_id
 
-# THe listening state of the ASR
+# The listening state of the ASR
 uint8 listent_state
 
-# The recognised result in case of evnet_id = RECOGNISED_UTT
+# The recognized result in case of event_id = RECOGNIZED_UTT
 asrresult recognized_utterance
 
 

--- a/pal_interaction_msgs/msg/ASRGrammarMngmt.msg
+++ b/pal_interaction_msgs/msg/ASRGrammarMngmt.msg
@@ -1,12 +1,12 @@
-# THis message is to be used in the ASR service to manage the grammars
-# it is possible to enable/disable, load/unload grammars.
+# This message is to be used in the ASR service to manage the grammars
+# makes possible to enable/disable, load/unload grammars.
 
 
-# Tyes of action
-int8 ENABLE = 0
-int8 DISABLE = 1
-int8 LOAD = 2
-int8 UNLOAD = 3
+# Types of action
+int8 ENABLE = 1
+int8 DISABLE = 2
+int8 LOAD = 3
+int8 UNLOAD = 4
 
 # Message variables
 # Type of action requested

--- a/pal_interaction_msgs/msg/ASRSrvRequest.msg
+++ b/pal_interaction_msgs/msg/ASRSrvRequest.msg
@@ -1,19 +1,19 @@
 # Request messages for the recognizer service.
-# It is possible to request and actiovation task, 
-# a grammar management task and lanaguage change or just
-# resquest the current status.
+# It is possible to request and activate task, 
+# a grammar management task and language change or just
+# request the current status.
 
 # Type of request list
-int8 ACTIVATION = 0
-int8 GRAMMAR = 1
-int8 LANGUAGE = 2
-int8 STATUS = 3
+int8 ACTIVATION = 1
+int8 GRAMMAR = 2
+int8 LANGUAGE = 3
+int8 STATUS = 4
 
 # Message variables
 # list of requests types (several requests can be send in one single message)
 int8[] requests
 
-# Informatino realted to each possible request
+# Information related to each possible request
 # except for status that does not need any additional info.
 ASRActivation activation
 ASRGrammarMngmt grammar

--- a/pal_interaction_msgs/msg/ASRSrvResponse.msg
+++ b/pal_interaction_msgs/msg/ASRSrvResponse.msg
@@ -1,4 +1,4 @@
-# THe status of the ASR with addition error or warning information
+# The status of the ASR with additional error or warning information
 ASRStatus status
 string error_msg
 string warn_msg

--- a/pal_interaction_msgs/msg/ASRStatus.msg
+++ b/pal_interaction_msgs/msg/ASRStatus.msg
@@ -1,9 +1,9 @@
-# THe status of the ASR
+# The status of the ASR
 # if it is active then active=true
 bool active
 
 # the current language 
-string langauge
+string language
 
 # the current enabled grammar
 string enabled_grammar

--- a/pal_interaction_msgs/msg/AudioDeviceDescription.msg
+++ b/pal_interaction_msgs/msg/AudioDeviceDescription.msg
@@ -11,13 +11,13 @@ string device_name
 uint32 sample_rate
 
 # sample size in bits
-uint8 sample_size
+int8 sample_size
 
 # format can be SIGNED or UNSIGNED
-uint8 format
+int8 format
 
 # buffer size used to acquire data.
 uint16 buffer_size
 
 # number of recorded channels
-uint8 number_of_channels
+int8 number_of_channels

--- a/pal_interaction_msgs/msg/AudioDeviceDescription.msg
+++ b/pal_interaction_msgs/msg/AudioDeviceDescription.msg
@@ -1,4 +1,4 @@
-# Desription of and audio device.
+# Description of an audio device.
 
 int8 SIGNED = 0
 int8 UNSIGNED = 1
@@ -7,7 +7,7 @@ int8 UNSIGNED = 1
 # name of the device (usually a portaudio name)
 string device_name
 
-# samples rate of the adquired audio signal
+# sample rate of the acquired audio signal
 uint32 sample_rate
 
 # sample size in bits
@@ -16,7 +16,7 @@ uint8 sample_size
 # format can be SIGNED or UNSIGNED
 uint8 format
 
-# buffer size used to adquire data.
+# buffer size used to acquire data.
 uint16 buffer_size
 
 # number of recorded channels

--- a/pal_interaction_msgs/msg/asrresult.msg
+++ b/pal_interaction_msgs/msg/asrresult.msg
@@ -1,10 +1,10 @@
 ## Message that containes the recognized utterance.
 ## Confidence values
-uint8 CONFIDENCE_UNDEFINED = -1
-uint8 CONFIDENCE_POOR = 1
-uint8 CONFIDENCE_LOW  = 2
-uint8 CONFIDENCE_GOOD = 3
-uint8 CONFIDENCE_MAX  = 4
+int8 CONFIDENCE_UNDEFINED = -1
+int8 CONFIDENCE_POOR = 1
+int8 CONFIDENCE_LOW  = 2
+int8 CONFIDENCE_GOOD = 3
+int8 CONFIDENCE_MAX  = 4
 
 # ASR result messages used by RosRecognizerServer
 
@@ -12,7 +12,7 @@ uint8 CONFIDENCE_MAX  = 4
 string text
 
 # confidence with values from POOR to MAX
-uint8 confidence
+int8 confidence
 
 # start and end of the recognizer uterance.
 time start

--- a/pal_interaction_msgs/msg/asrresult.msg
+++ b/pal_interaction_msgs/msg/asrresult.msg
@@ -1,6 +1,6 @@
 ## Message that containes the recognized utterance.
 ## Confidence values
-uint8 CONFIDENCE_UNDEFINED = 0
+uint8 CONFIDENCE_UNDEFINED = -1
 uint8 CONFIDENCE_POOR = 1
 uint8 CONFIDENCE_LOW  = 2
 uint8 CONFIDENCE_GOOD = 3
@@ -11,10 +11,10 @@ uint8 CONFIDENCE_MAX  = 4
 # text recognized
 string text
 
-# confidence with values fomr POOR to MAX
+# confidence with values from POOR to MAX
 uint8 confidence
 
-# estart and end of the recognizer uterance.
+# start and end of the recognizer uterance.
 time start
 time end
 

--- a/pal_interaction_msgs/msg/asrupdate.msg
+++ b/pal_interaction_msgs/msg/asrupdate.msg
@@ -1,6 +1,6 @@
 # V.1.0 of the ASR ROS API for the servie.
-# just has the language and grammar to enable, the actustic models to be used,
-# and wether we want to activate or diactivate the recognizer.
+# just has the language and grammar to enable, the acoustic models to be used,
+# and whether we want to activate or deactivate the recognizer.
 string language
 string enable_grammar
 string disable_grammar


### PR DESCRIPTION
Fixing using 0 on some enums and some minor typos.
