### PR TITLE
Add ActuatorCurrentLimit message.

### DIFF
--- a/pal_control_msgs/CMakeLists.txt
+++ b/pal_control_msgs/CMakeLists.txt
@@ -1,14 +1,19 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(pal_control_msgs)
 
-find_package(catkin REQUIRED COMPONENTS message_generation actionlib_msgs)
+find_package(catkin REQUIRED COMPONENTS message_generation
+                                        std_msgs
+                                        actionlib_msgs)
 
 include_directories(include)
 
+add_message_files(DIRECTORY msg FILES ActuatorCurrentLimit.msg)
 add_action_files(DIRECTORY action FILES MotionManager.action)
 
 add_service_files(FILES CurrentLimit.srv)
 
 generate_messages(DEPENDENCIES actionlib_msgs)
 
-catkin_package(CATKIN_DEPENDS message_runtime actionlib_msgs)
+catkin_package(CATKIN_DEPENDS message_runtime
+                              std_msgs
+                              actionlib_msgs)

--- a/pal_control_msgs/msg/ActuatorCurrentLimit.msg
+++ b/pal_control_msgs/msg/ActuatorCurrentLimit.msg
@@ -1,0 +1,9 @@
+# Names of the actuators whose current limit is being set
+string[] actuator_names
+
+# Actuator current limits. Values belong to the [0, 1] interval, are
+# non-dimensional and represent the fraction of an actuator's maximum allowed
+# current, e.g., 0.5 would set an actuator's current limit to half its
+# maximum value.
+float64[] current_limits
+

--- a/pal_control_msgs/package.xml
+++ b/pal_control_msgs/package.xml
@@ -12,8 +12,10 @@
 
   <build_depend>message_generation</build_depend>
   <build_depend>actionlib_msgs</build_depend>
+  <build_depend>std_msgs</build_depend>
 
   <run_depend>message_runtime</run_depend>
   <run_depend>actionlib_msgs</run_depend>
+  <run_depend>std_msgs</run_depend>
 
 </package>


### PR DESCRIPTION
Message type for setting the current limit for a group of actuators.

This is part of a larger set of interfaces that aim at exposing current limiting capabilities, and is yet another stab at what PRs #9 and #10 have proposed. Consider this a further iteration of these efforts.
#### Rationale
- A separate message type is convenient in the sense that it can be readily streamed via topic pub-sub, and can also be included in service req-rep, if needed.
- The message fields being arrays allows to specify current limits to one or more actuators, and mimics the structure of other ROS messages, like `sensor_msgs::JointState` and `trajectory_msgs::JointTrajectory`.
#### The big picture

The idea is to have the following interfaces (this PR deals with the first one only):
- **ROS message** `pal_control_msgs::ActuatorCurrentLimit`
- **ros_control types**
  - **Handle** `pal_ros_control::CurrentLimitHandle`
  
  ``` c++
  class CurrentLimitHandle
  {
  public:
    CurrentLimitHandle();
    CurrentLimitHandle(const std::string& name, double* curr_lim);
  
    std::string getName() const;
    double      getCurrentLimit() const;
    void        setCurrentLimit(double curr_lim);
  };
  ```
  - **Interface** `pal_ros_control::CurrentLimitInterface`, which does not claim its resources
- **ros_control controller**
  - `pal_ros_controllers::CurrentLimitController`
  - Is configured from a yaml file with this structure
  
  ``` yaml
    head_current_limit_controller:
    type: "pal_ros_controllers/CurrentLimitController"
    actuators:
      - head_1_motor
      - head_2_motor
  ```
  - Takes `pal_control_msgs::ActuatorCurrentLimit` commands  from a topic interface
#### Feedback needed

Apart from giving feedback on this particular PR, please also comment on the overall naming and structure of the other interfaces, as they should be coherent.

One particular aspect that I'm not decided on, is that the message name makes it explicit that we're dealing with actuators, while the `ros_control` side drops this identifier for brevity. What are your preferences?.

If we reach some consensus here, I can push to our private repo an implementation of the `ros_control` parts to our internal repo, while remaining compatible with existing code until we determine a migration path, if any.

@awesomebytes, @bmagyar, @lucamarchionni, @po1, @v-lopez 
